### PR TITLE
macOS support with short options only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-output_files/
+output_files/*
 .env
 .idea/
 

--- a/README.md
+++ b/README.md
@@ -63,22 +63,32 @@ Once GaPTools is setup, to execute it on the included sample study, run the belo
 ./dbgap-docker.bash -i ./input_files/1000_Genomes_Study/ -o ./output_files/1000_Genomes_Study -m ./input_files/1000_Genomes_Study/metadata.json up
 ```
 
-GaPTools uses Apache Airflow behind the scenes as the workflow orchestrator to perform all the validation tasks. To view the validation results of the dbGaP validation tool, browse to the following URL:
+GaPTools uses [Apache Airflow](https://airflow.apache.org/) behind the scenes as the workflow orchestrator to perform all the validation tasks. To view the validation results of the dbGaP validation tool, browse to the following URL:
 
 ```
 http://<your_docker_host_ip>:8080
 ```  
 
+If you are running this locally on a workstation, this can often be found at http://localhost:8080. 
+
+
 At the end of the workflow, the output files will be created under the specified output directory.
+
 ## Usage
 
 To use GaPTools for your study, modify the above command and pass as input parameters:
 
-- __`-i`__ -- path to the input files for your study
+- __`-i path/to/INPUT_DIR`__ -- path to the input files for your study (may also use `--input [...]` on Linux OS's)
 
-- __`-o`__ -- path where output files should be generated
+- __`-o path/to/OUTPUT_DIR`__ -- path where output files should be generated (may also use `--output [...]` on Linux OS's)
 
-- __`-m`__ -- path to the manifest file for your study
+- __`-m path/to/metadata.json`__ -- path to the manifest file for your study (may also use `--manifest [...]` on Linux OS's)
+
+- __`-h`__ -- print full usage information at the command line (may also use `--help` on Linux OS's)
+ 
+### Note on macOS
+
+On macOS, only the short versions of the command line options are supported.  (`-i`, `-o`, `-m`, `-h`)
 
 ## Stop Docker Containers
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ At the end of the workflow, the output files will be created under the specified
 
 To use GaPTools for your study, modify the above command and pass as input parameters:
 
-__-i__ -- path to the input files for your study
+- __`-i`__ -- path to the input files for your study
 
-__-o__ -- path where output files should be generated
+- __`-o`__ -- path where output files should be generated
 
-__-m__ -- path to the manifest file for your study
+- __`-m`__ -- path to the manifest file for your study
 
 ## Stop Docker Containers
 
@@ -88,4 +88,4 @@ Once your study is processed, run the below command to stop the GaPTools service
 ```
 
 ## Contact
-If you have any questions or to report any issues, please contact us at: [dbgap-help@ncbi.nlm.nih.gov](dbgap-help@ncbi.nlm.nih.gov)
+If you have any questions or to report any issues, please contact us at: [dbgap-help@ncbi.nlm.nih.gov](mailto:dbgap-help@ncbi.nlm.nih.gov)

--- a/dbgap-docker.bash
+++ b/dbgap-docker.bash
@@ -141,7 +141,7 @@ while true; do
     esac
 done
 
-if docker-compose version 2>&1 > /dev/null ; then
+if command -v docker-compose > /dev/null ; then
    DOCKER_COMPOSE_COMMAND="docker-compose"
 elif docker compose version 2>&1 > /dev/null ; then
    DOCKER_COMPOSE_COMMAND="docker compose"

--- a/dbgap-docker.bash
+++ b/dbgap-docker.bash
@@ -11,7 +11,7 @@
 #+
 #% DESCRIPTION
 #%    This script runs GaPTools to validate data files
-#%    to be submitted to dbGaP. It loads a docker-compose
+#%    to be submitted to dbGaP. It loads a Docker Compose
 #%    file and runs required docker containers.
 #%
 #%
@@ -141,6 +141,16 @@ while true; do
     esac
 done
 
+if docker-compose version 2>&1 > /dev/null ; then
+   DOCKER_COMPOSE_COMMAND="docker-compose"
+elif docker compose version 2>&1 > /dev/null ; then
+   DOCKER_COMPOSE_COMMAND="docker compose"
+else
+   echo "Docker Compose not found"
+   usage
+   exit 2
+fi
+
 ##################
 # Verify up/down arguments were supplied properly
 ##################
@@ -157,11 +167,11 @@ if ! [[ "${DSTATE}" =~ ^(up|down)$ ]]; then
 fi
 
 #########################
-# Run the docker-compose commands to bring the environment down
+# Run the $DOCKER_COMPOSE_COMMAND commands to bring the environment down
 # Skips the rest of the validation and exit the script
 #########################
 if [ $DSTATE == "down" ]; then
-   docker-compose -f docker-compose-CeleryExecutor.yml down
+   $DOCKER_COMPOSE_COMMAND -f docker-compose-CeleryExecutor.yml down
    exit
 fi
 
@@ -217,7 +227,7 @@ if [ ! -f "$MANIFEST" ]; then
 fi
 
 ########################
-# Create a .env file to be used by docker-compose
+# Create a .env file to be used by $DOCKER_COMPOSE_COMMAND
 ########################
 echo "OUTPUT_VOL=${OUTPUT_DIR}" > .env
 echo "INPUT_VOL=${INPUT_DIR}" >> .env
@@ -267,11 +277,11 @@ docker_check() {
 }
 
 #########################
-# Run the docker-compose commands to bring the environment up
+# Run the $DOCKER_COMPOSE_COMMAND commands to bring the environment up
 #########################
 if [ $DSTATE == "up" ]; then
    docker pull ncbi/gaptools:latest
-   docker-compose -f docker-compose-CeleryExecutor.yml up -d
+   $DOCKER_COMPOSE_COMMAND -f docker-compose-CeleryExecutor.yml up -d
    i=0
    while ! docker_check
    do


### PR DESCRIPTION
This allows macOS users to run GaPTools.  

macOS's `getopt` is based on the BSD version which does not support long command line options like `--help`. 

The changes detect `darwin*` os types, forces using the short command line options (`-h`, etc.), and prints a warning as appropriate.  

This addresses #14.

It also improves the output_files directory in the repo .gitignore, removed a few trailing whitespace characters on a few lines. It also fixes and improves formatting, and adds and fixes links in the README.md .

On some Docker installations, Compose is accessible via `docker compose` and not `docker-compose` and this works around this by searching for both and using the one it finds.  
